### PR TITLE
(feat) Synchronize video queue and player

### DIFF
--- a/app/scripts/controllers/videoqueue.js
+++ b/app/scripts/controllers/videoqueue.js
@@ -28,24 +28,27 @@ angular.module('jetgrizzlyApp')
 
     $scope.$on('videoEnded', function() {
       $scope.$apply(function() {
-        //This is showing as undefined
-        var newVid = $scope.queue[0].$value.split('v=')[1];
-        console.log("Newvid is: ", newVid);
-        $scope.removeFirst();
-        videoRef.child('currentVideo').set(newVid);
+        console.log('Video Queue CTRL has heard videoEnded Event');
+        if ($scope.queue.length > 0) {
+          var newVid = $scope.queue[0].$value.split('v=')[1];
+          console.log('Newvid is: ', newVid);
+          $scope.removeFirst();
+          videoRef.child('currentVideo').set(newVid);
+        } else {
+          console.log('Video Queue CTRL: There are no videos to play.');
+        }
       });
     });
 
-    $scope.testEvent = function() {
-      var newVid = $scope.queue[0].$value.split('v=')[1];
-      console.log("Newvid is: ", newVid);
-      $scope.removeFirst();
-      videoRef.child('currentVideo').set(newVid);
-    };
-
     $scope.addToQueue = function(item) {
-      console.log(item);
+      console.log('Link added: '+item);
       $scope.queue.$add(item);
+      console.log('Queue size: '+$scope.queue.length);
+
+      //This function needs to know: 1) If there is a video currently playing, 2) The current size of the queue
+      //If queue.length > 0, push item into queue
+      //If queue.length === 0 && video is playing, push item into queue
+      //If queue.length === 0 && video is not playing, change currentVideo in firebase and start playing video right away
     };
 
     $scope.removeFirst = function() {

--- a/app/scripts/room/room.js
+++ b/app/scripts/room/room.js
@@ -1,4 +1,5 @@
 'use strict';
+/*jshint -W020 */
 module = angular.module('jetgrizzlyApp.Room', ['ui.router']).config(function ($stateProvider) {
   $stateProvider.state('lobby', {
     url: '/',
@@ -9,125 +10,117 @@ module = angular.module('jetgrizzlyApp.Room', ['ui.router']).config(function ($s
     }
   });
 })
-  .controller('PlayerController',function ($scope, $window, playerFactory, config) {
-  //Initial settings
-   $scope.yt = {
-    width: 640,
-    height: 390
-   };
-
-  //Link up with songqueue, insert new property of videoID
-  // i.e. videoID: song.split('=')[1]
-  $scope.queueSong = function () {
-    playerFactory.playSong($scope.songUrl);
-  };
-
-}).factory('playerFactory', function () {
-  //queueSong function from controller calls this
+.controller('PlayerController',function ($scope, $window, config) {
+//Initial settings
+ $scope.yt = {
+  width: 640,
+  height: 390
+ };
 })
-  .directive('youtube', function ($rootScope, $window, config, $firebase) {
-    return {
-      //elements attribute settings i.e. id, height attrs
-      restrict: 'E',
-      scope: {
-        //bind attrs to our directive scope
-        //one way binding - data changed in the view is updated in javascript
-        height: '@',
-        width: '@',
-        videoid: '@'        
-      },
+.directive('youtube', function ($rootScope, $window, config, $firebase) {
+  return {
+    //elements attribute settings i.e. id, height attrs
+    restrict: 'E',
+    scope: {
+      //bind attrs to our directive scope
+      //one way binding - data changed in the view is updated in javascript
+      height: '@',
+      width: '@',
+      videoid: '@'        
+    },
 
-      //template to put inside of directive
-      template: '<div></div>',
-      link: function (scope, element) {
-        //Load the iFrame player API code asynchronously
-        var tag = element.append('<script src="https://www.youtube.com/iframe_api">');
+    //template to put inside of directive
+    template: '<div></div>',
+    link: function (scope, element) {
+      //Load the iFrame player API code asynchronously
+      var tag = element.append('<script src="https://www.youtube.com/iframe_api">');
 
-        var player;
+      var player;
 
-        $window.onYouTubeIframeAPIReady = function () {
-          var isPlaying;
-          var youTubeFirebase = new $window.Firebase(config.firebase.url+'/youTube');
-          var videoFirebase = new $window.Firebase(config.firebase.url+'/youTube/currentVideo')
+      $window.onYouTubeIframeAPIReady = function () {
+        var isPlaying;
+        var youTubeFirebase = new $window.Firebase(config.firebase.url+'/youTube');
+        var videoFirebase = new $window.Firebase(config.firebase.url+'/youTube/currentVideo');
+        var videoObj = $firebase(videoFirebase).$asObject();
 
-          youTubeFirebase.once('value', function(snap){
-            var youtubeInfo = snap.val();
-            console.log(youtubeInfo.isPlaying);
+        youTubeFirebase.once('value', function(snap){
+          var youtubeInfo = snap.val();
+          console.log(youtubeInfo.isPlaying);
 
-            if(youtubeInfo.isPlaying){
-              console.log('video should be playing');
-              var currentVideo = youtubeInfo.currentVideo;
-              var startTime = Math.floor((Date.now() - youtubeInfo.startTime) / 1000);
-              console.log(startTime);
-              console.log(currentVideo);
+          if(youtubeInfo.isPlaying){
+            var currentVideo = youtubeInfo.currentVideo;
+            var startTime = Math.floor((Date.now() - youtubeInfo.startTime) / 1000);
+            console.log('A video is currently playing: '+currentVideo);
+            console.log('Start time: '+startTime);
 
-              player = new window.YT.Player(element.children()[0], {
-                playerVars: {
-                  autoplay: 1,
-                  html5: 1,
-                  start: startTime
-               },
-               //This will allow the view to change in real time
-                height: scope.height,
-                width: scope.width,
-                videoId: currentVideo,
-                events: {
-                  'onStateChange': function(event){
-                    console.log("youtube player has a stateChange");
-                    console.log("Event data ", event.data);
-                    if(event.data === 1){
-                      console.log("youtube player video ended")
-                      $rootScope.$broadcast('videoEnded');
-                    }
+            player = new window.YT.Player(element.children()[0], {
+              playerVars: {
+                autoplay: 1,
+                html5: 1,
+                start: startTime
+             },
+             //This will allow the view to change in real time
+              height: scope.height,
+              width: scope.width,
+              videoId: currentVideo,
+              events: {
+                'onStateChange': function(event){
+                  console.log('youtube player has a stateChange');
+                  console.log('Event data ', event.data);
+                  if(event.data === 0){
+                    console.log('youtube player video ended');
+                    $rootScope.$broadcast('videoEnded');
                   }
                 }
-             });
-            }
-            else {
-              player = new window.YT.Player(element.children()[0], {
-                playerVars: {
-                  autoplay: 0,
-                  html5: 1,
-                },
-                //This will allow the view to change in real time
-                height: scope.height,
-                width: scope.width,
-                videoId: scope.videoid,
-                events: {
-                  'onStateChange': function(event){
-                    console.log("youtube player has a stateChange");
-                    console.log("Event data ", event.data);
-                    if(event.data === 1){
-                      console.log("youtube player video ended")
-                      $rootScope.$broadcast('videoEnded');
-                    }
+              }
+           });
+          } else {
+            player = new window.YT.Player(element.children()[0], {
+              playerVars: {
+                autoplay: 0,
+                html5: 1,
+              },
+              //This will allow the view to change in real time
+              height: scope.height,
+              width: scope.width,
+              videoId: scope.videoid,
+              events: {
+                'onStateChange': function(event){
+                  console.log('youtube player has a stateChange');
+                  console.log('Event data ', event.data);
+                  if(event.data === 0){
+                    console.log('youtube player video ended');
+                    $rootScope.$broadcast('videoEnded');
                   }
                 }
-              });       
-            }
-          });
-          
-          //If a change is made to videoid via input box in view, this will see the change and runs callback
-          videoFirebase.on('child_changed', function(childSnapshot, prevChildName){
-             console.log('firebase value changed');
-             youTubeFirebase.child('startTime').set(Date.now());
-             youTubeFirebase.child('isPlaying').set(true);
-             youTubeFirebase.child('currentVideo').set(childSnapshot);
-             console.log('childSnapshot', childSnapshot)
-             player.loadVideoById({'videoId': childSnapshot.val()}); 
-          });
-        };
-
-        scope.$watch('videoid', function (newValue, oldValue) {
-          if (newValue !== oldValue) {
-            console.log("setting new video value")
-            var firebase = new Firebase(config.firebase.url+'/youTube');
-            firebase.child('startTime').set(Date.now());
-            firebase.child('isPlaying').set(true);
-            firebase.child('currentVideo').set(newValue); 
+              }
+            });       
           }
         });
-      }
-    };
+        
+        //Alex, there is an issue with this listener. Right now it works fine when there is already a video playing
+        //And there are videos in the queue, but setting 'startTime' and 'isPlaying' triggers a new round of
+        //'child_changed' events, which sets off another. When the queue is empty and the first video is entered, this
+        //kicks off an infinite loop. We should change it so that we don't listen for changes on 'startTime' or 'isPlaying'
+        youTubeFirebase.on('child_changed', function(childSnapshot, prevChildName){
+           console.log('Room.js sees new video');
+           youTubeFirebase.child('startTime').set(Date.now());
+           youTubeFirebase.child('isPlaying').set(true);
+           console.log('childSnapshot', childSnapshot);
+           player.loadVideoById({'videoId': childSnapshot.val()}); 
+        });
+      };
+
+      scope.$watch('videoid', function (newValue, oldValue) {
+        if (newValue !== oldValue) {
+          console.log('setting new video value');
+          var firebase = new $window.Firebase(config.firebase.url+'/youTube');
+          firebase.child('startTime').set(Date.now());
+          firebase.child('isPlaying').set(true);
+          firebase.child('currentVideo').set(newValue); 
+        }
+      });
+    }
+  };
 });
 

--- a/app/views/room/playback.html
+++ b/app/views/room/playback.html
@@ -10,7 +10,6 @@
         <input type="text" ng-model="item" ng-minlength="6" ng-pattern="/^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#\&\?]*).*/" class="queueInput" name="vidInput" placeholder="Enter a Youtube URL Here">
         <button class="submit btn btn-default" ng-click="addToQueue(item)">Add</button>
         <button class="submit btn btn-default" ng-click="removeFirst()">Remove</button>
-        <button class="submit btn btn-default" ng-click="testEvent()">Test</button>
         <span class="error" ng-show="queueForm.vidInput.$error.minlength">This field is required</span>
         <span class="error" ng-show="queueForm.vidInput.$error.pattern">URL Must be from Youtube</span>
       </form>


### PR DESCRIPTION
So the player / queue syncing is now working for the base case (videos in queue, player already playing a video). There are still problems we need to work out. Namely:

1) The listener in room.js on line 105 is checking for any changes made to children of the youTubeFirebase ref, and then it makes changes to children of the firebase ref (lines 107 and 108), kicking off another whole round of listening and setting... This doesn't stop the base case from functioning correctly, but we should probably refactor this. See the comments I left for you in the code.

2) The 'addToQueue' function in controllers/videoqueue.js (line 43) needs to know if the player is currently playing a video in order to know how to store links added to the queue. <strong>Any ideas how we can do this?</strong>

3) Right now, if the player ends and there are no videos in the queue, playing stops. This is expected. However, when a new link is added the player doesn't start playing because of #2 above. I can add logic to the queue to handle this case as long as I can know if the player is playing right now or not.

TL:DR: base case is working, we have more work to do to make it more robust. But this is a step in the right direction!
