### PR TITLE
(fix) Improvements to queue logic, more resolution on player state

### DIFF
--- a/app/scripts/controllers/videoqueue.js
+++ b/app/scripts/controllers/videoqueue.js
@@ -42,8 +42,17 @@ angular.module('jetgrizzlyApp')
 
     $scope.addToQueue = function(item) {
       console.log('Link added: '+item);
-      $scope.queue.$add(item);
-      console.log('Queue size: '+$scope.queue.length);
+      $scope.queue.$add(item).then(function(){
+        console.log('Queue size: '+$scope.queue.length+'; Player is in state: '+$scope.playerState);
+        //The if statement below never gets triggered because playerState never
+        //gets set to 0 somehow... or it gets set back to 1 insanely quickly...
+        if ($scope.queue.length === 1 && $scope.playerState === 0) {
+          var newVid = $scope.queue[0].$value.split('v=')[1];
+          console.log('Newvid is: ', newVid);
+          $scope.removeFirst();
+          videoRef.child('currentVideo').set(newVid);
+        }
+      });
 
       //This function needs to know: 1) If there is a video currently playing, 2) The current size of the queue
       //If queue.length > 0, push item into queue
@@ -52,6 +61,8 @@ angular.module('jetgrizzlyApp')
     };
 
     $scope.removeFirst = function() {
-      $scope.queue.$remove($scope.queue[0]);
+      $scope.queue.$remove($scope.queue[0]).then(function(){
+        console.log('Queue size: '+$scope.queue.length+'; Player is in state: '+$scope.playerState);
+      });
     };
   }]);

--- a/app/scripts/room/room.js
+++ b/app/scripts/room/room.js
@@ -66,10 +66,21 @@ module = angular.module('jetgrizzlyApp.Room', ['ui.router']).config(function ($s
               events: {
                 'onStateChange': function(event){
                   console.log('youtube player has a stateChange');
-                  console.log('Event data ', event.data);
-                  if(event.data === 0){
+                  if (event.data === 0){
                     console.log('youtube player video ended');
+                    $rootScope.playerState = 1;
                     $rootScope.$broadcast('videoEnded');
+                  } else if (event.data === 1) {
+                    console.log('Player is playing');
+                    $rootScope.playerState = 1;
+                  } else if (event.data === 2) {
+                    console.log('Player is paused');
+                    $rootScope.playerState = 2;
+                  } else if (event.data === 3) {
+                    console.log('Player is buffering');
+                    $rootScope.playerState = 3;
+                  } else {
+                    console.log(event.data);
                   }
                 }
               }
@@ -87,10 +98,21 @@ module = angular.module('jetgrizzlyApp.Room', ['ui.router']).config(function ($s
               events: {
                 'onStateChange': function(event){
                   console.log('youtube player has a stateChange');
-                  console.log('Event data ', event.data);
-                  if(event.data === 0){
+                  if (event.data === 0){
                     console.log('youtube player video ended');
+                    $rootScope.playerState = 0;
                     $rootScope.$broadcast('videoEnded');
+                  } else if (event.data === 1) {
+                    console.log('Player is playing');
+                    $rootScope.playerState = 1;
+                  } else if (event.data === 2) {
+                    console.log('Player is paused');
+                    $rootScope.playerState = 2;
+                  } else if (event.data === 3) {
+                    console.log('Player is buffering');
+                    $rootScope.playerState = 3;
+                  } else {
+                    console.log(event.data);
                   }
                 }
               }


### PR DESCRIPTION
Working the bugs out the the queue/player relationship. This code is an improvement, but there are still a number of issues.
- Listeners in room.js are still listening to themselves... creates an infinite loop sometimes and app crashes
- When last video ends and no videos are in queue, $rootScope.playerState is somehow still set to 1 (playing). This prevents the queue from automatically sending the first added song over to the player.

We'll figure it out tommorrow!
