### PR TITLE
(fix) Fix Broken Server Logic

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -35,6 +35,6 @@ angular.module('jetgrizzlyApp', [
 })
 .factory('config',function(){
   return {
-    firebase:{url:'https://blistering-heat-6745.firebaseio.com'}
+    firebase:{url:'https://dazzling-torch-2714.firebaseio.com'}
   };
 });

--- a/app/scripts/room/room.js
+++ b/app/scripts/room/room.js
@@ -42,7 +42,7 @@ var module = angular.module('jetgrizzlyApp.Room', ['ui.router']).config(function
       $window.onYouTubeIframeAPIReady = function () {
         var youTubeFirebase = new $window.Firebase(config.firebase.url+'/youTube');
         var videoFirebase = new $window.Firebase(config.firebase.url+'/youTube/currentVideo');
-        var videoObj = $firebase(videoFirebase).$asObject();
+        var stateObj = $firebase(youTubeFirebase).$asObject();
 
         youTubeFirebase.once('value', function(snap){
           var youtubeInfo = snap.val();

--- a/index.js
+++ b/index.js
@@ -13,11 +13,11 @@ server.listen(port, ip, function () {
   console.log('Express server listening on %d!', port);
 });
 
-var videoSet = false;
-var queueRef = new Firebase('https://blistering-heat-6745.firebaseio.com/queue/');
-var videoRef = new Firebase('https://blistering-heat-6745.firebaseio.com/youTube/');
+var queueRef = new Firebase('https://dazzling-torch-2714.firebaseio.com/queue/');
+var videoRef = new Firebase('https://dazzling-torch-2714.firebaseio.com/youTube/');
 //Will use beenCalled to throttle the number of calls to this listener
 var beenCalled = false;
+
 //Listen for changes to player state from firebase
 videoRef.on('value', function (snapshot) {
   //Print whether this callback chain has already been called for the value change
@@ -38,8 +38,10 @@ videoRef.on('value', function (snapshot) {
           //Get the queue in array form
           var index = 0;
           var videoQueue = [];
+          var nameQueue = [];
           queue.forEach(function(queueEntry){
             videoQueue[index] = queueEntry.val();
+            nameQueue[index] = queueEntry.name();
             index ++;
           });
           //Parse the first link
@@ -48,11 +50,14 @@ videoRef.on('value', function (snapshot) {
           //Set the currentVideo in firebase to the first item in queue s
           var currentVideo = videoRef.child('currentVideo');
           currentVideo.set(nextVid, function(){
-            console.log("next vid saved");
+            console.log('next vid saved');
             //Once next video has been sent, change beenCalled back to false
             beenCalled = false;
+            var remove = new Firebase('https://dazzling-torch-2714.firebaseio.com/queue/'+nameQueue[0]);
+            remove.remove(function(){
+              console.log('removed top vid from queue');
+            });
           });
-
         }
       });
     } else {
@@ -61,6 +66,31 @@ videoRef.on('value', function (snapshot) {
   }
 }, function (errorObject) {
   console.log('The read failed: ' + errorObject.code);
+});
+
+//To handle case of empty queue and stopped player, listen for added children to queue
+queueRef.on('child_added', function(snap) {
+  var nextName = snap.name();
+  var nextID = snap.val().split('v=')[1];
+  console.log('song added to queue', nextName);
+  //When a child is added, check to see if the player is playing
+  videoRef.once('value', function(player) {
+    console.log('isPlaying: ', player.val().isPlaying);
+    //If the player isn't playing
+    if (!player.val().isPlaying) {
+      console.log('start playing this video');
+      var currentVideo = videoRef.child('currentVideo');
+      //Send the newly added video to the player
+      currentVideo.set(nextID, function(){
+        console.log('next vid saved');
+        //Once next video has been sent, change beenCalled back to false
+        var remove = new Firebase('https://dazzling-torch-2714.firebaseio.com/queue/'+nextName);
+        remove.remove(function(){
+          console.log('removed top vid from queue');
+        });
+      });
+    }
+  });
 });
 
 // Expose app


### PR DESCRIPTION
This PR implements a server queue that works for the base cases in my testing. I'm not convinced it is working in all cases and I'm also not sure that we won't see the same type of issues with this server as with the client queue logic because I'm not sure that my throttling strategy is working.

Basically, every client is still updating firebase by setting youTube/isPlaying to false every time it finishes. The server hears each of those changes and attempts to throttle how many times it changes the next song by setting a flag to true ('beenCalled' on line 27 of index.js) when the first change has been triggered.

This could also potentially be solved on the client side, by having the player check if 'isPlaying' had been already set to false before trying make it false again.

This code is not pretty, I'm not proud of it, but it appears to work correctly. It needs to be tested with multiple people using the room simultaneously and adding videos. It is ugly, but heavily commented. I believe you should be able to see what I am trying to do.
